### PR TITLE
Add HTTP-based discovery

### DIFF
--- a/stun/http.go
+++ b/stun/http.go
@@ -1,0 +1,88 @@
+package stun
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+)
+
+// The serviceURLs map contains the URLs where HTTP-based discovery services can be
+// contacted together with the JSON key where the public IP is expected to be found.
+var serviceURLs = map[string]string{
+	"https://ipconfig.io/json":            "ip",
+	"https://api64.ipify.org?format=json": "ip",
+	// "http://ip-api.com/json/":          "query", // ip-api only provides IPv4 discovery!
+}
+
+// GetPubIPOverHTTP leverages HTTP-based services allowing us to retrieve our public IPv4 or IPv6
+// address. Its implementation respects the IP version preferences configured in the OS. That usually
+// translates to trying IPv6 before IPv4, but your mileage may vary depending on your OS' network stack
+// configuration. The implementation currently supports the following Ip discovery services:
+//   - ipconfig.io
+//   - ipify.org
+func GetPubIPOverHTTP() (net.IP, error) {
+	// Let's try every endpoint until one works!
+	for url, key := range serviceURLs {
+		slog.Debug("trying to get public IP over HTTP", "url", url)
+
+		rawIP, err := doRequest(url, key)
+		if err != nil {
+			slog.Warn("error getting the raw public IP", "err", err)
+			continue
+		}
+
+		pIP, err := parseRawIP(rawIP)
+		if err != nil {
+			slog.Warn("couldn't parse the raw IP...")
+			continue
+		}
+
+		return pIP, nil
+	}
+	return nil, fmt.Errorf("couldn't get public IP address and we exhausted URLs")
+}
+
+// Function doRequest simply carries out an HTTP request to an IP discovery service to then
+// extract the public IP from the returned payload as a string.
+func doRequest(url, key string) (string, error) {
+	req, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer req.Body.Close()
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return "", err
+	}
+
+	rawPayload := map[string]interface{}{}
+	if err := json.Unmarshal(body, &rawPayload); err != nil {
+		return "", fmt.Errorf("error unmarshaling the payload: %w", err)
+	}
+
+	rawIP, ok := rawPayload[key]
+	if !ok {
+		return "", fmt.Errorf("key %q not found in rawPayload", key)
+	}
+
+	ipStr, ok := rawIP.(string)
+	if !ok {
+		return "", fmt.Errorf("raw IP %v could't be cast to a string", rawIP)
+	}
+
+	return ipStr, nil
+}
+
+// Function parseRawIP simply wraps the parsing of IPvX addresses from strings with
+// the appropriate error handling.
+func parseRawIP(rawIP string) (net.IP, error) {
+	pIP := net.ParseIP(rawIP)
+	if pIP == nil {
+		return pIP, fmt.Errorf("couldn't parse the raw IP %q", rawIP)
+	}
+	return pIP, nil
+}

--- a/stun/stun.go
+++ b/stun/stun.go
@@ -1,4 +1,4 @@
-package glowd
+package stun
 
 // Consider using github.com/tailscale/tailscale/net/stun instead!
 import (
@@ -94,7 +94,7 @@ var (
 	}
 )
 
-func GetExternalIP(ipFamily IPFamily) (net.IP, error) {
+func GetPubIPOverSTUN(ipFamily IPFamily) (net.IP, error) {
 	// Parse a STUN URI
 	u, err := stun.ParseURI(stunServers[0])
 	if err != nil {

--- a/stun/stun_test.go
+++ b/stun/stun_test.go
@@ -1,4 +1,4 @@
-package glowd
+package stun
 
 import (
 	"fmt"
@@ -16,29 +16,38 @@ func TestGetExternalIp(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			extIPv4, err := GetExternalIP(IPv4)
+			var pubIP net.IP
+			var err error
+
+			pubIP, err = GetPubIPOverSTUN(IPv4)
 			if err != nil {
 				t.Errorf("GetExternalIP(IPv4) errored out: %v", err)
 			}
-			fmt.Printf("discovered external IPv4: %s\n", extIPv4)
+			fmt.Printf("discovered external IPv4: %s\n", pubIP)
 
-			extIPv6, err := GetExternalIP(IPv6)
+			pubIP, err = GetPubIPOverSTUN(IPv6)
 			if err != nil {
 				t.Errorf("GetExternalIP(IPv6) errored out: %v", err)
 			}
-			fmt.Printf("discovered external IPv6: %s\n", extIPv6)
+			fmt.Printf("discovered external IPv6: %s\n", pubIP)
 
-			locIPv4, err := GetDefaultOutboundIP(IPv4)
+			pubIP, err = GetDefaultOutboundIP(IPv4)
 			if err != nil {
 				t.Errorf("GetDefaultOutboundIP(IPv4) errored out: %v", err)
 			}
-			fmt.Printf("   discovered local IPv4: %s\n", locIPv4)
+			fmt.Printf("   discovered local IPv4: %s\n", pubIP)
 
-			locIPv6, err := GetDefaultOutboundIP(IPv6)
+			pubIP, err = GetDefaultOutboundIP(IPv6)
 			if err != nil {
 				t.Errorf("GetDefaultOutboundIP(IPv6) errored out: %v", err)
 			}
-			fmt.Printf("   discovered local IPv6: %s\n", locIPv6)
+			fmt.Printf("   discovered local IPv6: %s\n", pubIP)
+
+			pubIP, err = GetPubIPOverHTTP()
+			if err != nil {
+				t.Errorf("GetPubIPOverHTTP() errored out: %v", err)
+			}
+			fmt.Printf("discovered external IPvx: %s\n", pubIP)
 
 			// Just so we know what to do on other tests!
 			// if err != nil || !net.IP.Equal(got, tt.want) {


### PR DESCRIPTION
We simply updated some naming stuff and added HTTP discovery. We should be good to go in terms of getting our public IPvX address!

Closes #14.