### PR TITLE
Set umask to 0000 before creating the named pipe

### DIFF
--- a/plugins/np/np.go
+++ b/plugins/np/np.go
@@ -41,6 +41,8 @@ func (np *NamedPipePlugin) Init() error {
 		return nil
 	}
 
+	oldmask := syscall.Umask(0o000)
+	defer syscall.Umask(oldmask)
 	// Consider using the unix package...
 	if err := syscall.Mkfifo(np.PipePath, 0666); err != nil {
 		return fmt.Errorf("couldn't create the named pipe: %w", err)


### PR DESCRIPTION
StoRM WebDAV runs as `storm` user, but the default umask is typically 0022 so the named pipe is not writable by other users.

flowd does the same thing: https://github.com/scitags/flowd/commit/6592f62ff5942a9b1ed1a46a995d50a50f938168

Related to https://github.com/scitags/flowd-go/issues/28