### PR TITLE
Fix configuration key for the np plugin

### DIFF
--- a/plugins/np/README.md
+++ b/plugins/np/README.md
@@ -44,7 +44,7 @@ options. The following replicates the default configuration:
 ```json
 {
     "plugins": {
-        "np": {
+        "namedPipe": {
             "maxReaders": 5,
             "buffSize": 1000,
             "pipePath": "np"

--- a/rpm/flowd-go.1.md
+++ b/rpm/flowd-go.1.md
@@ -76,7 +76,7 @@ This section lists the configuration options available for each of the provided 
 refer to the documentation accompanying the implementation, which can be found on the URL provided in the DESCRIPTION. The
 setting's value type is enclosed in brackets (`[]`) and its default value is enclosed in braces (`{}`).
 
-## np
+## namedPipe
 The **named pipe** plugin will create a FIFO through a call to `mkfifo(3)` on which it will listen for flow events. Available
 settings are:
 


### PR DESCRIPTION
Simply update the doc so as to reflect the actual name of the named pipe plugin in the implementation; closes #28.