### PR TITLE
Support hostname as collector address

### DIFF
--- a/backends/fireflyb/firefly.go
+++ b/backends/fireflyb/firefly.go
@@ -5,7 +5,6 @@ import (
 	"hash/maphash"
 	"log/slog"
 	"net"
-	"strings"
 
 	glowdTypes "github.com/scitags/flowd-go/types"
 )
@@ -49,13 +48,7 @@ func (b *FireflyBackend) Init() error {
 	slog.Debug("initialising the firefly backend")
 
 	if b.SendToCollector {
-		addressFmt := "%s:%d"
-		// If we got an IPv6 address...
-		if pIP := net.ParseIP(b.CollectorAddress); pIP != nil && strings.Contains(b.CollectorAddress, ":") {
-			addressFmt = "[%s]:%d"
-		}
-
-		conn, err := net.Dial("udp", fmt.Sprintf(addressFmt, b.CollectorAddress, b.CollectorPort))
+		conn, err := net.Dial("udp", parseCollectorAddress(b.CollectorAddress, b.CollectorPort))
 		if err != nil {
 			return fmt.Errorf("couldn't initialize UDP socket: %w", err)
 		}

--- a/backends/fireflyb/firefly_test.go
+++ b/backends/fireflyb/firefly_test.go
@@ -1,0 +1,28 @@
+package fireflyb
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestParseCollectorAddress(t *testing.T) {
+	port := 1234
+
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"0.0.0.0", fmt.Sprintf("0.0.0.0:%d", port)},
+		{"127.0.0.1", fmt.Sprintf("127.0.0.1:%d", port)},
+		{"example.net", fmt.Sprintf("example.net:%d", port)},
+		{"example.org", fmt.Sprintf("example.org:%d", port)},
+		{"::1", fmt.Sprintf("[::1]:%d", port)},
+		{"fe80::3333:2222:1111:0000", fmt.Sprintf("[fe80::3333:2222:1111:0000]:%d", port)},
+	}
+
+	for _, test := range tests {
+		if got := parseCollectorAddress(test.in, port); got != test.want {
+			t.Errorf("got %s != %s", got, test.want)
+		}
+	}
+}

--- a/backends/fireflyb/utils.go
+++ b/backends/fireflyb/utils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"strings"
 	"syscall"
 	"time"
 
@@ -197,4 +198,18 @@ func (b *FireflyBackend) hashFlowID(flowID glowdTypes.FlowID) uint64 {
 	slog.Debug("hashed flowID", "hash", hash)
 
 	return hash
+}
+
+// Function parseCollectorAddress handles the specified collector address
+// and provides an address suitable for net.Dial.
+func parseCollectorAddress(rawAddress string, port int) string {
+	// This address format is suitable both for hostnames and raw IPv4 addresses.
+	addressFmt := "%s:%d"
+
+	// If we got an IPv6 address...
+	if pIP := net.ParseIP(rawAddress); pIP != nil && strings.Contains(rawAddress, ":") {
+		addressFmt = "[%s]:%d"
+	}
+
+	return fmt.Sprintf(addressFmt, rawAddress, port)
 }


### PR DESCRIPTION
For example, it is useful to use `eu.scitags.org` as the collector.

Related to #28